### PR TITLE
Enable PureScript

### DIFF
--- a/src/file_types.zig
+++ b/src/file_types.zig
@@ -211,12 +211,13 @@ pub const php = .{
     .injections = @embedFile("tree-sitter-php/queries/injections.scm"),
 };
 
-// conflicts with haskell
-// pub const purescript = .{
-//     .extensions = &[_][]const u8{"purs"},
-//     .comment = "--",
-//     .injections = @embedFile("tree-sitter-purescript/queries/injections.scm"),
-// };
+pub const purescript = .{
+    .color = 0x14161a,
+    .icon = "",
+    .extensions = &[_][]const u8{"purs"},
+    .comment = "--",
+    .injections = @embedFile("tree-sitter-purescript/queries/injections.scm"),
+};
 
 pub const python = .{
     .color = 0xffd845,


### PR DESCRIPTION
Closes #1

Depends on updating https://github.com/neurocyte/tree-sitter

The conflict with Haskell has been resolved in https://github.com/postsolar/tree-sitter-purescript/pull/17/commits/e40d749975c43ef9764c567044b98c6329ab142b
